### PR TITLE
Do no require "use_frameworks!" the podfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ Install the `Firebase/Messaging` pod:
 cd ios && pod init
 pod install Firebase/Messaging
 ```
-uncomment the "use_frameworks!" line in the podfile.
 
 ### Non Cocoapod approach
 


### PR DESCRIPTION
Update README to remove the line that says to uncomment the "use_frameworks!" line.